### PR TITLE
Fix datetime conversion by replace pd.to_datetime with datetime64 class

### DIFF
--- a/python_dwd/additionals/helpers.py
+++ b/python_dwd/additionals/helpers.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePosixPath
 from zipfile import ZipFile
 
 import pandas as pd
+from numpy import datetime64
 from tqdm import tqdm
 
 from python_dwd.additionals.variables import STRING_STATID_COL
@@ -77,8 +78,8 @@ def create_metaindex(parameter: Parameter,
 
     columns = metaindex.columns
     META_INDEX_DTYPES = {columns[0]: int,
-                         columns[1]: pd.to_datetime,
-                         columns[2]: pd.to_datetime,
+                         columns[1]: datetime64,
+                         columns[2]: datetime64,
                          columns[3]: float,
                          columns[4]: float,
                          columns[5]: float,
@@ -185,8 +186,8 @@ def metaindex_for_1minute_data(parameter: Parameter,
 
     columns = metadata_df.columns
     META_INDEX_DTYPES = {columns[0]: int,
-                         columns[1]: pd.to_datetime,
-                         columns[2]: pd.to_datetime,
+                         columns[1]: datetime64,
+                         columns[2]: datetime64,
                          columns[3]: float,
                          columns[4]: float,
                          columns[5]: float,


### PR DESCRIPTION
I fixed possible errors with datetime conversion using pd.to_datetime. I compared both files for more_precip and kl, both daily resolution and histroical period. There were obviously no differences between both metadata files but still, the conversion would throw an error for the kl file. That's why I replaced pd.to_datetime with the datetime64 class from numpy and this way there's no more problems.