### PR TITLE
Work on 1 minute metadata

### DIFF
--- a/python_dwd/additionals/helpers.py
+++ b/python_dwd/additionals/helpers.py
@@ -204,8 +204,6 @@ def parse_zipped_data_into_df(file_opened: open) -> pd.DataFrame:
 
     Args:
         file_opened (open) - the file that will be read
-        engine (str) - the parameter for read_csv engine, which is set here because the function is used with both
-        engines as sometimes it fails and thus it can be tried to get a success with the other engine
 
     Return:
         A pandas DataFrame with the read data.

--- a/python_dwd/additionals/helpers.py
+++ b/python_dwd/additionals/helpers.py
@@ -21,8 +21,8 @@ from python_dwd.constants.ftp_credentials import DWD_SERVER, DWD_PATH, \
 from python_dwd.constants.metadata import METADATA_COLUMNS, \
     METADATA_MATCHSTRINGS, METADATA_1MIN_GEO_MATCHSTRINGS, \
     METADATA_1MIN_PAR_MATCHSTRINGS, FILELIST_NAME, FTP_METADATA_NAME, \
-    ARCHIVE_FORMAT, DATA_FORMAT, METADATA_FIXED_COLUMN_WIDTH, STRING_STATID_COL
-from python_dwd.constants.variables import TRIES_TO_DOWNLOAD_FILE
+    ARCHIVE_FORMAT, DATA_FORMAT, METADATA_FIXED_COLUMN_WIDTH, STRING_STATID_COL, \
+    STATE_NAME, STATIONDATA_SEP, NA_STRING, TRIES_TO_DOWNLOAD_FILE
 from python_dwd.download.download_services import create_remote_file_name
 from python_dwd.download.ftp_handling import FTP
 from python_dwd.enumerations.parameter_enumeration import Parameter
@@ -123,7 +123,7 @@ def metaindex_for_1minute_data(parameter: Parameter,
 
     metaindex_df = metaindex_df.append(other=metadata_dfs, ignore_index=True)
 
-    metaindex_df.loc[:,"STATE"] = np.nan
+    metaindex_df.loc[:, STATE_NAME] = np.nan
 
     metaindex_df = metaindex_df.astype(METADATA_DTYPE_MAPPING)
 
@@ -179,11 +179,8 @@ def combine_geo_and_par_file_to_metadata_df(metadata_file: BytesIO) -> pd.DataFr
 
         for filetype, file in files_of_geo_and_par.items():
             with zip_file.open(file) as file_opened:
-                try:
-                    df = parse_zipped_data_into_df(file_opened)
-                except UnicodeDecodeError:
-                    df = parse_zipped_data_into_df(file_opened,
-                                                   engine='python')
+
+                df = parse_zipped_data_into_df(file_opened)
 
             df.columns = [GERMAN_TO_ENGLISH_COLUMNS_MAPPING.get(
                 name.strip().upper(), name.strip().upper())
@@ -201,8 +198,7 @@ def combine_geo_and_par_file_to_metadata_df(metadata_file: BytesIO) -> pd.DataFr
     return dfs_of_geo_and_par["geo_file"].loc[:, METADATA_COLUMNS]
 
 
-def parse_zipped_data_into_df(file_opened: open,
-                              engine: str = 'c') -> pd.DataFrame:
+def parse_zipped_data_into_df(file_opened: open) -> pd.DataFrame:
     """ A wrapper for read_csv of pandas library that has set the typically used parameters in the found data of the
     german weather service.
 
@@ -216,10 +212,10 @@ def parse_zipped_data_into_df(file_opened: open,
 
     """
     file = pd.read_csv(filepath_or_buffer=TextIOWrapper(file_opened),
-                       sep=";",
-                       na_values="-999",
-                       engine=engine,
+                       sep=STATIONDATA_SEP,
+                       na_values=NA_STRING,
                        dtype=str)
+
     return file
 
 

--- a/python_dwd/constants/metadata.py
+++ b/python_dwd/constants/metadata.py
@@ -24,3 +24,7 @@ DATE_FORMAT = "%Y%m%d"
 STRING_STATID_COL = 2
 METADATA_FIXED_COLUMN_WIDTH = [(0, 5), (5, 14), (14, 23), (23, 38),
                                (38, 50), (50, 60), (60, 102), (102, 200)]
+NA_STRING = "-999"
+STATIONDATA_SEP = ";"
+TRIES_TO_DOWNLOAD_FILE = 3
+

--- a/python_dwd/constants/variables.py
+++ b/python_dwd/constants/variables.py
@@ -1,3 +1,0 @@
-""" all other constants/variables used in the library """
-
-TRIES_TO_DOWNLOAD_FILE = 3

--- a/python_dwd/metadata_dwd.py
+++ b/python_dwd/metadata_dwd.py
@@ -133,7 +133,7 @@ def metadata_for_dwd_data(parameter: Parameter,
         metainfo = metaindex_for_1minute_data(parameter=parameter,
                                               time_resolution=time_resolution)
 
-    if all(np.isnan(metainfo[STATE_NAME])):
+    if all(pd.isnull(metainfo[STATE_NAME])):
         mdp = metadata_for_dwd_data(Parameter.PRECIPITATION_MORE,
                                     TimeResolution.DAILY,
                                     PeriodType.HISTORICAL,

--- a/python_dwd/parsing_data/parse_data_from_files.py
+++ b/python_dwd/parsing_data/parse_data_from_files.py
@@ -1,17 +1,12 @@
 """ function to read data from dwd server """
-from datetime import datetime as dt
-from pathlib import Path
 from typing import List
-from zipfile import ZipFile
 from io import BytesIO
 
 import pandas as pd
 
-from python_dwd.additionals.functions import check_parameters
-from python_dwd.additionals.functions import determine_parameters
 from python_dwd.constants.column_name_mapping import DATE_NAME, \
     GERMAN_TO_ENGLISH_COLUMNS_MAPPING
-from python_dwd.constants.metadata import STATIONDATA_MATCHSTRINGS, DATA_FORMAT
+from python_dwd.constants.metadata import DATA_FORMAT, NA_STRING, STATIONDATA_SEP
 
 
 def parse_dwd_data(files_in_bytes: List[BytesIO],
@@ -43,8 +38,8 @@ def parse_dwd_data(files_in_bytes: List[BytesIO],
     for file in files_in_bytes:
         try:
             data_file = pd.read_csv(filepath_or_buffer=file,
-                                    sep=";",
-                                    na_values="-999")
+                                    sep=STATIONDATA_SEP,
+                                    na_values=NA_STRING)
 
             data.append(data_file)
 


### PR DESCRIPTION
I did changes on the 1 minute metadata:
- I tested the function after the recent changes (where saving the zip on the disk was replaced by storing it in bytes) and it seemed to me, that the old errors, where one engine of pandas would fail for some file, wasn't popping up anymore. This way I removed the double try-except by simply using the default engine ("c") always. I also used this issue to remove the set strings for nas ("-999") and the seperator (";") by variables that are set in the metadata constants.