### PR TITLE
Fix minor glitch within "collect_dwd_data"

### DIFF
--- a/python_dwd/data_collection.py
+++ b/python_dwd/data_collection.py
@@ -65,7 +65,7 @@ def collect_dwd_data(station_ids: List[int],
         print(f"Data for {request_string} will be collected from internet.")
 
         remote_files = create_file_list_for_dwd_server(
-            station_ids, parameter, time_resolution, period_type, folder, create_new_filelist)
+            [station_id], parameter, time_resolution, period_type, folder, create_new_filelist)
 
         filenames_and_files = download_dwd_data(remote_files, parallel_download)
 


### PR DESCRIPTION
Dear Daniel and Benjamin,

we found a minor glitch (probably coming from a typo) which was hard to spot but we believe is an important fix.

### Rationale
As the body of the `collect_dwd_data()` method already iterates over the set of `station_ids`, we should pass the **single** `station_id` down to `create_file_list_for_dwd_server()` instead of all the `station_ids` again.

Otherwise, when redundantly adding data for **all** obtained `station_ids` within each iteration, the data frame will contain duplicate information which happened to show bad behavior for us when working on the CLI feature as outlined within #50.

Specifically, Pandas would croak with `ValueError("cannot reindex from a duplicate axis")` when applying boolean filters on indices of concatenated data frames containing duplicate data. We are aiming at filtering as outlined within #22 here.

Notwithstanding the above, `store_dwd_data()` would also have stored data from multiple stations within `station_data` associated to a single station `station_id`.

With kind regards,
Andreas.