### PR TITLE
Add command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__/
 dwd_data/
 .idea/
+.venv*
+*.egg-info

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+
+markers =
+    remote: Tests accessing the internet.

--- a/python_dwd/additionals/util.py
+++ b/python_dwd/additionals/util.py
@@ -1,0 +1,49 @@
+""" A set of utility functions """
+import sys
+import logging
+
+from docopt import docopt
+from munch import Munch, munchify
+
+
+def setup_logging(level=logging.INFO):
+    log_format = '%(asctime)-15s [%(name)-30s] %(levelname)-7s: %(message)s'
+    logging.basicConfig(
+        format=log_format,
+        stream=sys.stderr,
+        level=level)
+
+    # Silence INFO messages from numexpr.
+    numexpr_logger = logging.getLogger('numexpr')
+    numexpr_logger.setLevel(logging.WARN)
+
+
+def normalize_options(options):
+    normalized = {}
+    for key, value in options.items():
+
+        # Add primary variant.
+        key = key.strip('--<>')
+        normalized[key] = value
+
+        # Add secondary variant.
+        key = key.replace('-', '_')
+        normalized[key] = value
+
+    return munchify(normalized, factory=OptionMunch)
+
+
+def read_list(data, separator=u','):
+    if data is None:
+        return []
+    result = list(map(lambda x: x.strip(), data.split(separator)))
+    if len(result) == 1 and not result[0]:
+        result = []
+    return result
+
+
+class OptionMunch(Munch):
+
+    def __setattr__(self, k, v):
+        super().__setattr__(k.replace('-', '_'), v)
+        super().__setattr__(k.replace('_', '-'), v)

--- a/python_dwd/cli.py
+++ b/python_dwd/cli.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+import sys
+import logging
+from docopt import docopt
+from dateparser import parse as parsedate
+import pandas as pd
+
+from python_dwd import __version__, metadata_for_dwd_data
+from python_dwd.additionals.util import normalize_options, setup_logging, read_list
+from python_dwd.dwd_station_request import DWDStationRequest
+from python_dwd.enumerations.parameter_enumeration import Parameter
+from python_dwd.enumerations.period_type_enumeration import PeriodType
+from python_dwd.enumerations.time_resolution_enumeration import TimeResolution
+
+log = logging.getLogger(__name__)
+
+
+def run():
+    """
+    Usage:
+      dwd stations --parameter=<parameter> --resolution=<resolution> --period=<period> [--persist] [--format=<format>]
+      dwd readings --station=<station> --parameter=<parameter> --resolution=<resolution> --period=<period> [--persist] [--date=<date>] [--format=<format>]
+      dwd about [parameters] [resolutions] [periods]
+      dwd --version
+      dwd (-h | --help)
+
+    Options:
+      --station=<station>           Comma-separated list of station identifiers
+      --parameter=<parameter>       Parameter/variable, e.g. "kl", "air_temperature", "precipitation", etc.
+      --resolution=<resolution>     Dataset resolution: "annual", "monthly", "daily", "hourly", "minute_10", "minute_1"
+      --period=<period>             Dataset period: "historical", "recent", "now"
+      --persist                     Save and restore data to filesystem w/o going to the network
+      --date=<date>                 Date for filtering data. Can be either a single date(time) or
+                                    an ISO-8601 time interval, see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals.
+      --format=<format>             Output format. [Default: json]
+      --version                     Show version information
+      --debug                       Enable debug messages
+      -h --help                     Show this screen
+
+
+    Examples:
+
+      # Get list of stations for daily climate summary data in JSON format
+      dwd stations --parameter=kl --resolution=daily --period=recent
+
+      # Get list of stations for daily climate summary data in CSV format
+      dwd stations --parameter=kl --resolution=daily --period=recent --format=csv
+
+      # Get daily climate summary data for stations 44 and 1048
+      dwd readings --station=44,1048 --parameter=kl --resolution=daily --period=recent
+
+      # Optionally save/restore to/from disk in order to avoid asking upstream servers each time
+      dwd readings --station=44,1048 --parameter=kl --resolution=daily --period=recent --persist
+
+      # Limit output to specific date
+      dwd readings --station=44,1048 --parameter=kl --resolution=daily --period=recent --date=2020-05-01
+
+      # Limit output to specified date range in ISO-8601 time interval format
+      dwd readings --station=44,1048 --parameter=kl --resolution=daily --period=recent --date=2020-05-01/2020-05-05
+
+      # The real power horse: Acquire data across historical+recent data sets
+      dwd readings --station=44,1048 --parameter=kl --resolution=daily --period=historical,recent --date=1969-01-01/2020-06-11
+
+    """
+
+    # Read command line options.
+    options = normalize_options(docopt(run.__doc__, version=f'dwd {__version__}'))
+
+    # Setup logging.
+    debug = options.get('debug')
+    log_level = logging.INFO
+    if debug:
+        log_level = logging.DEBUG
+    setup_logging(log_level)
+
+    if options.about:
+        about(options)
+        return
+
+    if options.stations:
+        df = metadata_for_dwd_data(
+            parameter=options.parameter,
+            time_resolution=options.resolution,
+            period_type=options.period,
+            write_file=options.persist,
+        )
+
+    elif options.readings:
+        request = DWDStationRequest(
+            station_ids=read_list(options.station),
+            # TODO: Would like to say "climate_summary" instead of "kl" here.
+            parameter=options.parameter,
+            time_resolution=options.resolution,
+            period_type=read_list(options.period),
+            humanized_column_names=True,
+        )
+        data = request.collect_data(
+            write_file=options.persist,
+            prefer_local=options.persist,
+        )
+        data = list(data)
+        if not data:
+            log.error('No data available for given constraints')
+            sys.exit(1)
+        df = pd.concat(data)
+
+    if options.readings:
+
+        # Filter by station.
+        #print(df[df['STATION_ID'] == 1048])
+
+        if options.date:
+
+            # Filter by time interval.
+            if '/' in options.date:
+                date_from, date_to = options.date.split('/')
+                date_from = parsedate(date_from)
+                date_to = parsedate(date_to)
+                df = df[(date_from <= df['DATE']) & (df['DATE'] <= date_to)]
+
+            # Filter by date.
+            else:
+                date = parsedate(options.date)
+                df = df[date == df['DATE']]
+
+    # Make column names lowercase.
+    df = df.rename(columns=str.lower)
+
+    # Output as JSON.
+    if options.format == 'json':
+        output = df.to_json(orient='records', date_format='iso', indent=4)
+
+    # Output as CSV.
+    elif options.format == 'csv':
+        output = df.to_csv(index=False, date_format='%Y-%m-%dT%H-%M-%S')
+
+    # Output as XLSX.
+    elif options.format == 'excel':
+        # TODO: Obtain output file name from command line.
+        log.info('Writing "output.xlsx"')
+        df.to_excel('output.xlsx', index=False)
+        return
+
+    else:
+        log.error('Output format must be one of "json", "csv", "excel".')
+        sys.exit(1)
+
+    print(output)
+
+
+def about(options):
+
+    def output(thing):
+        for item in thing:
+            if item:
+                print('-', item.value)
+
+    if options.parameters:
+        output(Parameter)
+
+    elif options.resolutions:
+        output(TimeResolution)
+
+    elif options.periods:
+        output(PeriodType)
+
+    else:
+        log.error('Invoke "dwd about" with one of "parameter", "resolution" or "period"')
+        sys.exit(1)

--- a/python_dwd/constants/column_name_mapping.py
+++ b/python_dwd/constants/column_name_mapping.py
@@ -1,28 +1,46 @@
 """ mapping from german column names to english column names"""
 from numpy import datetime64
-from python_dwd.enumerations.column_names_enumeration import DWDOrigColumns, DWDColumns
+from python_dwd.enumerations.column_names_enumeration import DWDOrigColumns, DWDMetaColumns, DWDDataColumns
 
 GERMAN_TO_ENGLISH_COLUMNS_MAPPING = {
-    DWDOrigColumns.STATION_ID.value:                DWDColumns.STATION_ID.value,
-    DWDOrigColumns.DATE.value:                      DWDColumns.DATE.value,
-    DWDOrigColumns.FROM_DATE.value:                 DWDColumns.FROM_DATE.value,
-    DWDOrigColumns.TO_DATE.value:                   DWDColumns.TO_DATE.value,
-    DWDOrigColumns.STATIONHEIGHT.value:             DWDColumns.STATIONHEIGHT.value,
-    DWDOrigColumns.LATITUDE.value:                  DWDColumns.LATITUDE.value,
-    DWDOrigColumns.LATITUDE_ALTERNATIVE.value:      DWDColumns.LATITUDE.value,
-    DWDOrigColumns.LONGITUDE.value:                 DWDColumns.LONGITUDE.value,
-    DWDOrigColumns.LONGITUDE_ALTERNATIVE.value:     DWDColumns.LONGITUDE.value,
-    DWDOrigColumns.STATIONNAME.value:               DWDColumns.STATIONNAME.value,
-    DWDOrigColumns.STATE.value:                     DWDColumns.STATE.value
+    DWDOrigColumns.STATION_ID.value:                DWDMetaColumns.STATION_ID.value,
+    DWDOrigColumns.DATE.value:                      DWDMetaColumns.DATE.value,
+    DWDOrigColumns.FROM_DATE.value:                 DWDMetaColumns.FROM_DATE.value,
+    DWDOrigColumns.TO_DATE.value:                   DWDMetaColumns.TO_DATE.value,
+    DWDOrigColumns.STATIONHEIGHT.value:             DWDMetaColumns.STATIONHEIGHT.value,
+    DWDOrigColumns.LATITUDE.value:                  DWDMetaColumns.LATITUDE.value,
+    DWDOrigColumns.LATITUDE_ALTERNATIVE.value:      DWDMetaColumns.LATITUDE.value,
+    DWDOrigColumns.LONGITUDE.value:                 DWDMetaColumns.LONGITUDE.value,
+    DWDOrigColumns.LONGITUDE_ALTERNATIVE.value:     DWDMetaColumns.LONGITUDE.value,
+    DWDOrigColumns.STATIONNAME.value:               DWDMetaColumns.STATIONNAME.value,
+    DWDOrigColumns.STATE.value:                     DWDMetaColumns.STATE.value,
+}
+
+GERMAN_TO_ENGLISH_COLUMNS_MAPPING_HUMANIZED = {
+    # Daily climate summary
+    DWDOrigColumns.FX.value: DWDDataColumns.FX.value,
+    DWDOrigColumns.FM.value: DWDDataColumns.FM.value,
+    DWDOrigColumns.RSK.value: DWDDataColumns.RSK.value,
+    DWDOrigColumns.RSKF.value: DWDDataColumns.RSKF.value,
+    DWDOrigColumns.SDK.value: DWDDataColumns.SDK.value,
+    DWDOrigColumns.SHK_TAG.value: DWDDataColumns.SHK_TAG.value,
+    DWDOrigColumns.NM.value: DWDDataColumns.NM.value,
+    DWDOrigColumns.VPM.value: DWDDataColumns.VPM.value,
+    DWDOrigColumns.PM.value: DWDDataColumns.PM.value,
+    DWDOrigColumns.TMK.value: DWDDataColumns.TMK.value,
+    DWDOrigColumns.UPM.value: DWDDataColumns.UPM.value,
+    DWDOrigColumns.TXK.value: DWDDataColumns.TXK.value,
+    DWDOrigColumns.TNK.value: DWDDataColumns.TNK.value,
+    DWDOrigColumns.TGK.value: DWDDataColumns.TGK.value,
 }
 
 METADATA_DTYPE_MAPPING = {
-    DWDColumns.STATION_ID.value:        int,
-    DWDColumns.FROM_DATE.value:         datetime64,
-    DWDColumns.TO_DATE.value:           datetime64,
-    DWDColumns.STATIONHEIGHT.value:     float,
-    DWDColumns.LATITUDE.value:          float,
-    DWDColumns.LONGITUDE.value:         float,
-    DWDColumns.STATIONNAME.value:       str,
-    DWDColumns.STATE.value:             str
+    DWDMetaColumns.STATION_ID.value:        int,
+    DWDMetaColumns.FROM_DATE.value:         datetime64,
+    DWDMetaColumns.TO_DATE.value:           datetime64,
+    DWDMetaColumns.STATIONHEIGHT.value:     float,
+    DWDMetaColumns.LATITUDE.value:          float,
+    DWDMetaColumns.LONGITUDE.value:         float,
+    DWDMetaColumns.STATIONNAME.value:       str,
+    DWDMetaColumns.STATE.value:             str
 }

--- a/python_dwd/constants/metadata.py
+++ b/python_dwd/constants/metadata.py
@@ -1,14 +1,14 @@
 """ metdata constants """
-from python_dwd.enumerations.column_names_enumeration import DWDColumns
+from python_dwd.enumerations.column_names_enumeration import DWDMetaColumns
 
-METADATA_COLUMNS = [DWDColumns.STATION_ID.value,
-                    DWDColumns.FROM_DATE.value,
-                    DWDColumns.TO_DATE.value,
-                    DWDColumns.STATIONHEIGHT.value,
-                    DWDColumns.LATITUDE.value,
-                    DWDColumns.LONGITUDE.value,
-                    DWDColumns.STATIONNAME.value,
-                    DWDColumns.STATE.value]
+METADATA_COLUMNS = [DWDMetaColumns.STATION_ID.value,
+                    DWDMetaColumns.FROM_DATE.value,
+                    DWDMetaColumns.TO_DATE.value,
+                    DWDMetaColumns.STATIONHEIGHT.value,
+                    DWDMetaColumns.LATITUDE.value,
+                    DWDMetaColumns.LONGITUDE.value,
+                    DWDMetaColumns.STATIONNAME.value,
+                    DWDMetaColumns.STATE.value]
 
 METADATA_MATCHSTRINGS = ['beschreibung', '.txt']
 METADATA_1MIN_GEO_PREFIX = "Metadaten_Geographie_"

--- a/python_dwd/data_collection.py
+++ b/python_dwd/data_collection.py
@@ -1,4 +1,5 @@
 """ Data collection pipeline """
+import logging
 from pathlib import Path
 from typing import List, Union
 import pandas as pd
@@ -11,6 +12,8 @@ from python_dwd.file_path_handling.file_list_creation import create_file_list_fo
 from python_dwd.download.download import download_dwd_data
 from python_dwd.parsing_data.parse_data_from_files import parse_dwd_data
 from python_dwd.data_storing import restore_dwd_data, store_dwd_data, _build_local_store_key
+
+log = logging.getLogger(__name__)
 
 
 def collect_dwd_data(station_ids: List[int],
@@ -60,13 +63,13 @@ def collect_dwd_data(station_ids: List[int],
 
             # When successful append data and continue with next iteration
             if not station_data.empty:
-                print(f"Data for {request_string} restored from local.")
+                log.info(f"Data for {request_string} restored from local.")
 
                 data.append(station_data)
 
                 continue
 
-        print(f"Data for {request_string} will be collected from internet.")
+        log.info(f"Data for {request_string} will be collected from internet.")
 
         remote_files = create_file_list_for_dwd_server(
             [station_id], parameter, time_resolution, period_type, folder, create_new_filelist)

--- a/python_dwd/data_collection.py
+++ b/python_dwd/data_collection.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Union
 import pandas as pd
 
+from python_dwd.constants.column_name_mapping import GERMAN_TO_ENGLISH_COLUMNS_MAPPING_HUMANIZED
 from python_dwd.enumerations.parameter_enumeration import Parameter
 from python_dwd.enumerations.period_type_enumeration import PeriodType
 from python_dwd.enumerations.time_resolution_enumeration import TimeResolution
@@ -24,7 +25,8 @@ def collect_dwd_data(station_ids: List[int],
                      prefer_local: bool = False,
                      parallel_download: bool = False,
                      write_file: bool = False,
-                     create_new_filelist: bool = False) -> pd.DataFrame:
+                     create_new_filelist: bool = False,
+                     humanize_column_names: bool = False) -> pd.DataFrame:
     """
     Function that organizes the complete pipeline of data collection, either
     from the internet or from a local file. It therefor goes through every given
@@ -42,6 +44,7 @@ def collect_dwd_data(station_ids: List[int],
         parallel_download: boolean if to use parallel download when downloading files
         write_file: boolean if to write data to local storage
         create_new_filelist: boolean if to create a new filelist for the data selection
+        humanize_column_names: boolean to yield column names better for human consumption
 
     Returns:
         a pandas DataFrame with all the data given by the station ids
@@ -84,4 +87,10 @@ def collect_dwd_data(station_ids: List[int],
 
         data.append(station_data)
 
-    return pd.concat(data, axis=1, ignore_index=True)
+    data = pd.concat(data)
+
+    # Assign meaningful column names (humanized).
+    if humanize_column_names:
+        data = data.rename(columns=GERMAN_TO_ENGLISH_COLUMNS_MAPPING_HUMANIZED)
+
+    return data

--- a/python_dwd/download/download.py
+++ b/python_dwd/download/download.py
@@ -11,14 +11,14 @@ import pandas as pd
 from python_dwd.constants.metadata import STATIONDATA_MATCHSTRINGS
 from python_dwd.download.download_services import create_remote_file_name
 from python_dwd.additionals.functions import find_all_matchstrings_in_string
-from python_dwd.enumerations.column_names_enumeration import DWDColumns
+from python_dwd.enumerations.column_names_enumeration import DWDMetaColumns
 
 
 def download_dwd_data(remote_files: pd.DataFrame,
                       parallel_download: bool = False) -> List[Tuple[str, BytesIO]]:
     """ wrapper for _download_dwd_data to provide a multiprocessing feature"""
 
-    remote_files: List[str] = remote_files[DWDColumns.FILENAME.value].to_list()
+    remote_files: List[str] = remote_files[DWDMetaColumns.FILENAME.value].to_list()
 
     if parallel_download:
         return list(

--- a/python_dwd/download/download.py
+++ b/python_dwd/download/download.py
@@ -1,7 +1,8 @@
 """ download scripts """
 from typing import List, Union, Tuple
 from pathlib import Path
-import urllib
+import urllib.request
+import urllib.error
 import zipfile
 from io import BytesIO
 from multiprocessing import Pool
@@ -53,7 +54,7 @@ def _download_dwd_data(remote_file: Union[str, Path]) -> BytesIO:
             zip_file = BytesIO(url_request.read())
     except urllib.error.URLError:
         raise urllib.error.URLError(f"Error: the stationdata {file_server} couldn't be reached.")
-    except urllib.error.HTTPERROR:
+    except urllib.error.HTTPError:
         pass
 
     try:

--- a/python_dwd/dwd_station_request.py
+++ b/python_dwd/dwd_station_request.py
@@ -15,7 +15,7 @@ from python_dwd.additionals.functions import check_parameters, cast_to_list
 from python_dwd.exceptions.start_date_end_date_exception import StartDateEndDateError
 
 from python_dwd.constants.access_credentials import DWD_FOLDER_MAIN
-from python_dwd.enumerations.column_names_enumeration import DWDColumns
+from python_dwd.enumerations.column_names_enumeration import DWDMetaColumns
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +30,8 @@ class DWDStationRequest:
                  time_resolution: Union[str, TimeResolution],
                  period_type: Union[None, str, list, PeriodType] = None,
                  start_date: Union[None, str, Timestamp] = None,
-                 end_date: Union[None, str, Timestamp] = None) -> None:
+                 end_date: Union[None, str, Timestamp] = None,
+                 humanized_column_names: bool = False) -> None:
 
         if not (period_type or (start_date and end_date)):
             raise ValueError("Define either a 'time_resolution' or both the 'start_date' and 'end_date' and "
@@ -93,6 +94,8 @@ class DWDStationRequest:
             raise ValueError("No combination for parameter, time_resolution "
                              "and period_type could be found.")
 
+        self.humanized_column_names = humanized_column_names
+
     def __eq__(self, other):
         return [self.station_ids,
                 self.parameter,
@@ -145,12 +148,13 @@ class DWDStationRequest:
                     parallel_download=parallel_download,
                     write_file=write_file,
                     create_new_filelist=create_new_filelist,
+                    humanize_column_names=self.humanized_column_names
                 )
 
                 # Filter out values which already are in the dataframe
                 try:
                     period_df = period_df[
-                        ~period_df[DWDColumns.DATE.value].isin(df_of_station_id[DWDColumns.DATE.value])]
+                        ~period_df[DWDMetaColumns.DATE.value].isin(df_of_station_id[DWDMetaColumns.DATE.value])]
                 except KeyError:
                     pass
 
@@ -159,9 +163,9 @@ class DWDStationRequest:
             # Filter for dates range if start_date and end_date are defined
             if self.start_date:
                 df_of_station_id = df_of_station_id[
-                    (df_of_station_id[DWDColumns.DATE.value] >= self.start_date) &
-                    (df_of_station_id[DWDColumns.DATE.value] <= self.end_date)
-                ]
+                    (df_of_station_id[DWDMetaColumns.DATE.value] >= self.start_date) &
+                    (df_of_station_id[DWDMetaColumns.DATE.value] <= self.end_date)
+                    ]
 
             # Empty dataframe should be skipped
             if df_of_station_id.empty:

--- a/python_dwd/dwd_station_request.py
+++ b/python_dwd/dwd_station_request.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import List, Union, Optional, Dict, Generator
 import pandas as pd
@@ -15,6 +16,8 @@ from python_dwd.exceptions.start_date_end_date_exception import StartDateEndDate
 
 from python_dwd.constants.access_credentials import DWD_FOLDER_MAIN
 from python_dwd.enumerations.column_names_enumeration import DWDColumns
+
+log = logging.getLogger(__name__)
 
 
 class DWDStationRequest:
@@ -80,9 +83,9 @@ class DWDStationRequest:
             if not check_parameters(parameter=self.parameter,
                                     time_resolution=self.time_resolution,
                                     period_type=period_type):
-                print(f"Combination of: parameter {self.parameter.value}, "
-                      f"time_resolution {self.time_resolution.value}, "
-                      f"period_type {period_type} not available and removed.")
+                log.info(f"Combination of: parameter {self.parameter.value}, "
+                         f"time_resolution {self.time_resolution.value}, "
+                         f"period_type {period_type} not available and removed.")
                 self.period_type.remove(period_type)
 
         # Use the clean up of self.period_type to identify if there's any data with those parameters

--- a/python_dwd/enumerations/column_names_enumeration.py
+++ b/python_dwd/enumerations/column_names_enumeration.py
@@ -24,9 +24,25 @@ class DWDOrigColumns(Enum):
     STATIONNAME = "STATIONSNAME"
     STATE = "BUNDESLAND"
 
+    # Daily climate summary
+    FX = "FX"
+    FM = "FM"
+    RSK = "RSK"
+    RSKF = "RSKF"
+    SDK = "SDK"
+    SHK_TAG = "SHK_TAG"
+    NM = "NM"
+    VPM = "VPM"
+    PM = "PM"
+    TMK = "TMK"
+    UPM = "UPM"
+    TXK = "TXK"
+    TNK = "TNK"
+    TGK = "TGK"
 
-class DWDColumns(Enum):
-    """ Overhauled column names for the library """
+
+class DWDMetaColumns(Enum):
+    """ Overhauled column names for metadata fields """
     STATION_ID = "STATION_ID"
     DATE = "DATE"
     FROM_DATE = "FROM_DATE"
@@ -41,3 +57,23 @@ class DWDColumns(Enum):
     FILENAME = "FILENAME"
     HAS_FILE = "HAS_FILE"
     FILEID = "FILEID"
+
+
+class DWDDataColumns(Enum):
+    """ Overhauled column names for data fields """
+
+    # Daily climate summary
+    FX = "WIND_GUST_MAX"
+    FM = "WIND_VELOCITY"
+    RSK = "PRECIPITATION_HEIGHT"
+    RSKF = "PRECIPITATION_FORM"
+    SDK = "SUNSHINE_DURATION"
+    SHK_TAG = "SNOW_DEPTH"
+    NM = "CLOUD_COVER"
+    VPM = "VAPOR_PRESSURE"
+    PM = "PRESSURE"
+    TMK = "TEMPERATURE"
+    UPM = "HUMIDITY"
+    TXK = "TEMPERATURE_MAX_200"
+    TNK = "TEMPERATURE_MIN_200"
+    TGK = "TEMPERATURE_MIN_005"

--- a/python_dwd/file_path_handling/file_list_creation.py
+++ b/python_dwd/file_path_handling/file_list_creation.py
@@ -7,7 +7,7 @@ from python_dwd.additionals.functions import check_parameters
 from python_dwd.additionals.helpers import create_fileindex
 from python_dwd.constants.access_credentials import DWD_FOLDER_MAIN, DWD_FOLDER_METADATA
 from python_dwd.constants.metadata import FILELIST_NAME, DATA_FORMAT
-from python_dwd.enumerations.column_names_enumeration import DWDColumns
+from python_dwd.enumerations.column_names_enumeration import DWDMetaColumns
 from python_dwd.enumerations.parameter_enumeration import Parameter
 from python_dwd.enumerations.period_type_enumeration import PeriodType
 from python_dwd.enumerations.time_resolution_enumeration import TimeResolution
@@ -68,8 +68,8 @@ def create_file_list_for_dwd_server(station_ids: List[int],
 
     filelist = pd.read_csv(filepath_or_buffer=filelist_local_path,
                            sep=",",
-                           dtype={DWDColumns.FILEID.value: int,
-                                  DWDColumns.STATION_ID.value: int,
-                                  DWDColumns.FILENAME.value: str})
+                           dtype={DWDMetaColumns.FILEID.value: int,
+                                  DWDMetaColumns.STATION_ID.value: int,
+                                  DWDMetaColumns.FILENAME.value: str})
 
-    return filelist.loc[filelist[DWDColumns.STATION_ID.value].isin(station_ids), :]
+    return filelist.loc[filelist[DWDMetaColumns.STATION_ID.value].isin(station_ids), :]

--- a/python_dwd/metadata_dwd.py
+++ b/python_dwd/metadata_dwd.py
@@ -6,7 +6,7 @@ import pandas as pd
 from python_dwd.additionals.functions import check_parameters
 from python_dwd.additionals.helpers import create_fileindex, check_file_exist
 from python_dwd.additionals.helpers import metaindex_for_1minute_data, create_metaindex
-from python_dwd.enumerations.column_names_enumeration import DWDColumns
+from python_dwd.enumerations.column_names_enumeration import DWDMetaColumns
 from python_dwd.constants.access_credentials import DWD_FOLDER_MAIN, \
     DWD_FOLDER_METADATA
 from python_dwd.constants.metadata import METADATA_NAME, DATA_FORMAT
@@ -48,7 +48,7 @@ def add_filepresence(metainfo: pd.DataFrame,
                          period_type=period_type,
                          folder=folder)
 
-    metainfo[DWDColumns.HAS_FILE.value] = False
+    metainfo[DWDMetaColumns.HAS_FILE.value] = False
 
     filelist = create_file_list_for_dwd_server(
         station_ids=metainfo.iloc[:, 0].to_list(),
@@ -58,7 +58,7 @@ def add_filepresence(metainfo: pd.DataFrame,
         folder=folder)
 
     metainfo.loc[metainfo.iloc[:, 0].isin(
-        filelist[DWDColumns.STATION_ID.value]), DWDColumns.HAS_FILE.value] = True
+        filelist[DWDMetaColumns.STATION_ID.value]), DWDMetaColumns.HAS_FILE.value] = True
 
     return metainfo
 
@@ -117,7 +117,7 @@ def metadata_for_dwd_data(parameter: Union[Parameter, str],
                                     time_resolution=time_resolution,
                                     period_type=period_type)
 
-    if all(pd.isnull(metainfo[DWDColumns.STATE.value])):
+    if all(pd.isnull(metainfo[DWDMetaColumns.STATE.value])):
         # @todo avoid calling function in function -> we have to build a function around to manage missing data
         mdp = metadata_for_dwd_data(Parameter.PRECIPITATION_MORE,
                                     TimeResolution.DAILY,
@@ -126,11 +126,11 @@ def metadata_for_dwd_data(parameter: Union[Parameter, str],
                                     write_file=False,
                                     create_new_filelist=False)
 
-        stateinfo = pd.merge(metainfo[DWDColumns.STATION_ID],
-                             mdp.loc[:, [DWDColumns.STATION_ID.value, DWDColumns.STATE.value]],
+        stateinfo = pd.merge(metainfo[DWDMetaColumns.STATION_ID],
+                             mdp.loc[:, [DWDMetaColumns.STATION_ID.value, DWDMetaColumns.STATE.value]],
                              how="left")
 
-        metainfo[DWDColumns.STATE.value] = stateinfo[DWDColumns.STATE.value]
+        metainfo[DWDMetaColumns.STATE.value] = stateinfo[DWDMetaColumns.STATE.value]
 
     metainfo = add_filepresence(metainfo=metainfo,
                                 parameter=parameter,

--- a/python_dwd/parsing_data/parse_data_from_files.py
+++ b/python_dwd/parsing_data/parse_data_from_files.py
@@ -1,4 +1,5 @@
 """ function to read data from dwd server """
+import logging
 from typing import List, Tuple
 from io import BytesIO
 import pandas as pd
@@ -6,6 +7,8 @@ import pandas as pd
 from python_dwd.additionals.helpers import create_stationdata_dtype_mapping
 from python_dwd.constants.column_name_mapping import GERMAN_TO_ENGLISH_COLUMNS_MAPPING
 from python_dwd.constants.metadata import NA_STRING, STATIONDATA_SEP
+
+log = logging.getLogger(__name__)
 
 
 def parse_dwd_data(filenames_and_files: List[Tuple[str, BytesIO]]) -> pd.DataFrame:
@@ -27,9 +30,9 @@ def parse_dwd_data(filenames_and_files: List[Tuple[str, BytesIO]]) -> pd.DataFra
     try:
         data = pd.concat(data).reset_index(drop=True)
     except ValueError:
-        print(f"An error occurred while concatenating the data for files "
-              f"{[filename for filename, file in filenames_and_files]}. "
-              f"An empty DataFrame will be returned.")
+        log.error(f"An error occurred while concatenating the data for files "
+                  f"{[filename for filename, file in filenames_and_files]}. "
+                  f"An empty DataFrame will be returned.")
         data = pd.DataFrame()
 
     return data
@@ -57,10 +60,10 @@ def _parse_dwd_data(filename_and_file: Tuple[str, BytesIO]) -> pd.DataFrame:
             dtype="str"  # dtypes are mapped manually to ensure expected dtypes
         )
     except pd.errors.ParserError:
-        print(f"The file representing {filename} could not be parsed and is skipped.")
+        log.warning(f"The file representing {filename} could not be parsed and is skipped.")
         return pd.DataFrame()
     except ValueError:
-        print(f"The file representing {filename} is None and is skipped.")
+        log.warning(f"The file representing {filename} is None and is skipped.")
         return pd.DataFrame()
 
     data = data.rename(columns=str.upper).rename(GERMAN_TO_ENGLISH_COLUMNS_MAPPING)

--- a/python_dwd/parsing_data/parse_data_from_files.py
+++ b/python_dwd/parsing_data/parse_data_from_files.py
@@ -66,6 +66,19 @@ def _parse_dwd_data(filename_and_file: Tuple[str, BytesIO]) -> pd.DataFrame:
         log.warning(f"The file representing {filename} is None and is skipped.")
         return pd.DataFrame()
 
-    data = data.rename(columns=str.upper).rename(GERMAN_TO_ENGLISH_COLUMNS_MAPPING)
+    # Column names contain spaces, so strip them away.
+    data = data.rename(columns=str.strip)
 
-    return data.astype(create_stationdata_dtype_mapping(data.columns))
+    # Make column names uppercase.
+    data = data.rename(columns=str.upper)
+
+    # End of record (EOR) has no value, so drop it right away.
+    data = data.drop(columns='EOR', errors='ignore')
+
+    # Assign meaningful column names (baseline).
+    data = data.rename(columns=GERMAN_TO_ENGLISH_COLUMNS_MAPPING)
+
+    # Coerce the data types appropriately.
+    data = data.astype(create_stationdata_dtype_mapping(data.columns))
+
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,9 @@ aiofiles==0.4.0
 ipython==7.10.1
 ipython-genutils==0.2.0
 matplotlib==3.0.3
-pytest==5.4.1
-mock==0.7.2
+pytest==5.4.3
+mock==4.0.2
 fire==0.3.1
+docopt==0.6.2
+munch==2.5.0
+dateparser==0.7.4

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,10 @@ setup(
     author_email='gutzemann@gmail.com',
     packages=['python_dwd'],  # , 'python_dwd.additionals'
     install_requires=['pandas', 'pathlib',
-                      'zipfile', 'scipy', 'numpy']
+                      'scipy', 'numpy'],
+    entry_points={
+        'console_scripts': [
+            'dwd = python_dwd.cli:run',
+        ]
+    },
 )

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -1,5 +1,5 @@
 from python_dwd.additionals.geo_location import get_nearest_station,\
-    derive_nearest_neighbours
+    _derive_nearest_neighbours
 from python_dwd.enumerations.parameter_enumeration import Parameter
 from python_dwd.enumerations.period_type_enumeration import PeriodType
 from python_dwd.enumerations.time_resolution_enumeration import TimeResolution
@@ -17,13 +17,13 @@ fixtures_dir = f"{os.path.dirname(__file__)}/../fixtures/"
     MagicMock(return_value=pd.read_json(f"{fixtures_dir}FIXED_METADATA.JSON"))
 )
 def test_get_nearest_station():
-    nearest_indices, distances = get_nearest_station(
+    nearest_station, distances = get_nearest_station(
         [50., 51.4], [8.9, 9.3],
         Parameter.TEMPERATURE_AIR,
         TimeResolution.HOURLY,
         PeriodType.RECENT)
 
-    assert nearest_indices == [4411, 15207]
+    assert nearest_station == 4411
 
     np.testing.assert_array_almost_equal(
         np.array(distances),
@@ -35,7 +35,7 @@ def test_derive_nearest_neighbours():
 
     metadata = pd.read_json(f"{fixtures_dir}FIXED_METADATA.JSON")
 
-    distances, indices_nearest_neighbours = derive_nearest_neighbours(
+    distances, indices_nearest_neighbours = _derive_nearest_neighbours(
         metadata.LAT.values,
         metadata.LON.values,
         coords)

--- a/tests/file_path_handling/test_file_list_creation.py
+++ b/tests/file_path_handling/test_file_list_creation.py
@@ -2,7 +2,7 @@ from python_dwd.file_path_handling.file_list_creation import create_file_list_fo
 from python_dwd.enumerations.period_type_enumeration import PeriodType
 from python_dwd.enumerations.time_resolution_enumeration import TimeResolution
 from python_dwd.enumerations.parameter_enumeration import Parameter
-from python_dwd.enumerations.column_names_enumeration import DWDColumns
+from python_dwd.enumerations.column_names_enumeration import DWDMetaColumns
 
 
 def test_create_file_list_for_dwd_server():
@@ -10,4 +10,4 @@ def test_create_file_list_for_dwd_server():
                                                        parameter=Parameter.CLIMATE_SUMMARY,
                                                        time_resolution=TimeResolution.DAILY,
                                                        period_type=PeriodType.RECENT)
-    assert remote_file_path[DWDColumns.FILENAME.value].tolist() == ['daily/kl/recent/tageswerte_KL_01048_akt.zip']
+    assert remote_file_path[DWDMetaColumns.FILENAME.value].tolist() == ['daily/kl/recent/tageswerte_KL_01048_akt.zip']


### PR DESCRIPTION
Dear Benjamin and Daniel,

as outlined within #50, we wanted to start bringing the features of this library to the command line similar to what users have been accustomed with [dwdweather2](https://github.com/panodata/dwdweather2).

Thanks again for the ongoing efforts you are putting into this library. Being able to acquire data across historical+recent data sets using the new `DWDStationRequest.collect_data()` method without having to assemble them manually in any way is really powerful.

While we haven't tested any other combinations of parameters other than those listed within the examples section of `dwd --help` yet, you might want to merge these updates right away when pulling in the `stationdata-request-definition` branch to master. Saying that, there might well be some fixups required in this matter to remedy quirks with more parameter combinations.

Cheers,
Andreas.