### PR TITLE
Fix filename cleansing within "create_fileindex"

### DIFF
--- a/python_dwd/additionals/helpers.py
+++ b/python_dwd/additionals/helpers.py
@@ -240,7 +240,7 @@ def create_fileindex(parameter: Parameter,
                                 dtype='str')
 
     files_server.loc[:, DWDColumns.FILENAME.value] = files_server.loc[:, DWDColumns.FILENAME.value].apply(
-        lambda filename: filename.lstrip(DWD_PATH + '/'))
+        lambda filename: filename.replace(DWD_PATH + '/', ''))
 
     files_server = files_server[files_server.FILENAME.str.contains(
         ARCHIVE_FORMAT)]


### PR DESCRIPTION
Hi there,

### Introduction
The description of the `lstrip` method is _»Return a copy of the string with leading characters removed.«_ While that sounds nice, it is not quite what we want here.

The syntax is actually `str.lstrip([chars])` where "chars" is a string specifying the **set of characters** to be removed. The chars argument is not a prefix; rather, all combinations 
of its values are stripped.

Actually, this goes south when trying to "strip away" the `DWD_PATH` prefix because "annual" will become "ual" and "monthly" will become "hly".

### Proof
```
>>> DWD_PATH = 'climate_environment/CDC/observations_germany/climate'
>>> filename = 'climate_environment/CDC/observations_germany/climate/annual/kl/historical/jahreswerte_KL_13777_20090101_20181231_hist.zip'

>>> filename.lstrip(DWD_PATH + '/')
'ual/kl/historical/jahreswerte_KL_13777_20090101_20181231_hist.zip'
```

Sad but true ;].

With kind regards,
Andreas.