### PR TITLE
Properly handle timestamps from "hourly" resolution data set

### DIFF
--- a/python_dwd/additionals/helpers.py
+++ b/python_dwd/additionals/helpers.py
@@ -303,3 +303,7 @@ def create_stationdata_dtype_mapping(columns: List[str]) -> dict:
             stationdata_dtype_mapping[column] = float
 
     return stationdata_dtype_mapping
+
+
+def convert_datetime_hourly(value):
+    return pd.to_datetime(value, format='%Y%m%d%H')

--- a/python_dwd/data_collection.py
+++ b/python_dwd/data_collection.py
@@ -79,7 +79,7 @@ def collect_dwd_data(station_ids: List[int],
 
         filenames_and_files = download_dwd_data(remote_files, parallel_download)
 
-        station_data = parse_dwd_data(filenames_and_files)
+        station_data = parse_dwd_data(filenames_and_files, time_resolution)
 
         if write_file:
             store_dwd_data(

--- a/tests/parsing_data/test_parse_data_from_files.py
+++ b/tests/parsing_data/test_parse_data_from_files.py
@@ -4,6 +4,7 @@ from io import StringIO, BytesIO
 from pathlib import Path
 import pandas as pd
 
+from python_dwd.enumerations.time_resolution_enumeration import TimeResolution
 from python_dwd.parsing_data.parse_data_from_files import parse_dwd_data
 
 fixtures_dir = Path(__file__, "../..").resolve().absolute() / "fixtures"
@@ -18,6 +19,8 @@ def test_parse_dwd_data():
     file_in_bytes.seek(0)
 
     station_data = parse_dwd_data(
-        filenames_and_files=[(filename, file_in_bytes)])
+        filenames_and_files=[(filename, file_in_bytes)],
+        time_resolution=TimeResolution.DAILY
+    )
 
     station_data.equals(station_data_original)

--- a/tests/test_data_collection.py
+++ b/tests/test_data_collection.py
@@ -119,7 +119,7 @@ def test_collect_dwd_data_empty():
 
 
 @pytest.mark.remote
-def test_fetch_and_parse_dwd_data_vanilla_columns():
+def test_collect_daily_vanilla():
     """ Test for data collection with real data """
 
     data = collect_dwd_data(
@@ -152,7 +152,7 @@ def test_fetch_and_parse_dwd_data_vanilla_columns():
 
 
 @pytest.mark.remote
-def test_fetch_and_parse_dwd_data_humanized_columns():
+def test_collect_daily_humanized():
     """ Test for data collection with real data and humanized column names """
 
     data = collect_dwd_data(
@@ -182,4 +182,24 @@ def test_fetch_and_parse_dwd_data_humanized_columns():
         'TEMPERATURE_MAX_200',
         'TEMPERATURE_MIN_200',
         'TEMPERATURE_MIN_005',
+    ]
+
+
+@pytest.mark.remote
+def test_collect_hourly_vanilla():
+    """ Test for data collection with real data """
+
+    data = collect_dwd_data(
+        station_ids=[1048],
+        parameter=Parameter.TEMPERATURE_AIR,
+        time_resolution=TimeResolution.HOURLY,
+        period_type=PeriodType.RECENT
+    )
+
+    assert list(data.columns.values) == [
+        'STATION_ID',
+        'DATE',
+        'QN_9',
+        'TT_TU',
+        'RF_TU',
     ]


### PR DESCRIPTION
Data from the `hourly` time resolution has a timestamp format of e.g. `2018121300`. So, let's parse it using the custom timestamp pattern `%Y%m%d%H`.
