### PR TITLE
Fix parameter typo within the "cli" feature

### DIFF
--- a/python_dwd/cli.py
+++ b/python_dwd/cli.py
@@ -92,7 +92,7 @@ def run():
             parameter=options.parameter,
             time_resolution=options.resolution,
             period_type=read_list(options.period),
-            humanized_column_names=True,
+            humanize_column_names=True,
         )
         data = request.collect_data(
             write_file=options.persist,

--- a/python_dwd/dwd_station_request.py
+++ b/python_dwd/dwd_station_request.py
@@ -31,7 +31,7 @@ class DWDStationRequest:
                  period_type: Union[None, str, list, PeriodType] = None,
                  start_date: Union[None, str, Timestamp] = None,
                  end_date: Union[None, str, Timestamp] = None,
-                 humanized_column_names: bool = False) -> None:
+                 humanize_column_names: bool = False) -> None:
 
         if not (period_type or (start_date and end_date)):
             raise ValueError("Define either a 'time_resolution' or both the 'start_date' and 'end_date' and "
@@ -94,7 +94,7 @@ class DWDStationRequest:
             raise ValueError("No combination for parameter, time_resolution "
                              "and period_type could be found.")
 
-        self.humanized_column_names = humanized_column_names
+        self.humanize_column_names = humanize_column_names
 
     def __eq__(self, other):
         return [self.station_ids,
@@ -148,7 +148,7 @@ class DWDStationRequest:
                     parallel_download=parallel_download,
                     write_file=write_file,
                     create_new_filelist=create_new_filelist,
-                    humanize_column_names=self.humanized_column_names
+                    humanize_column_names=self.humanize_column_names
                 )
 
                 # Filter out values which already are in the dataframe


### PR DESCRIPTION
Hi there,

this adjusts the parameter name `humanize_column_names`. I named it a bit different before and that typo has slipped through somehow.

With kind regards,
Andreas.