### PR TITLE
Fix data acquisition for solar data from hourly and daily resolutions

### DIFF
--- a/python_dwd/additionals/helpers.py
+++ b/python_dwd/additionals/helpers.py
@@ -220,10 +220,15 @@ def create_fileindex(parameter: Parameter,
                                f"{time_resolution.value}_"
                                f"{period_type.value}{DATA_FORMAT}")
 
-    server_path = PurePosixPath(DWD_PATH,
-                                time_resolution.value,
-                                parameter.value,
-                                period_type.value)
+    if parameter == Parameter.SOLAR and time_resolution in (TimeResolution.HOURLY, TimeResolution.DAILY):
+        server_path = PurePosixPath(DWD_PATH,
+                                    time_resolution.value,
+                                    parameter.value)
+    else:
+        server_path = PurePosixPath(DWD_PATH,
+                                    time_resolution.value,
+                                    parameter.value,
+                                    period_type.value)
 
     try:
         with FTP(DWD_SERVER) as ftp:


### PR DESCRIPTION
Hi again,

### Introduction
This is another thing we learned from maintaining [`dwdweather2`](https://github.com/panodata/dwdweather2) I would like to share in form of code with you.

### Anomaly
The DWD directory structure has an anomaly: For **solar** data, there are no "recent" or "historical" folders within the "hourly" and "daily" time resolutions, see [1,2]. Sad but true.

### Outlook
When applying this minor fix accounting for the deviation outlined above, this command starts working flawlessly:
```
dwd readings --station=183,662 --parameter=solar --resolution=daily --period=recent --date=2020-05-31
```

As soon as #63 gets merged, it should probably also start working for hourly data.

With kind regards,
Andreas.

[1] https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/hourly/solar/
[2] https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/daily/solar/
